### PR TITLE
deb: add the ability to specify "Origin", "Label" and "Description"

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ So you may skip them in command line invocation in case you have aws config.
 
 ## Environment variables reference
 
-`GPG_SIGN_KEY` - the name of the key that will be used to sign package metadata.
+* `GPG_SIGN_KEY` - the name of the key that will be used to sign package metadata.
 
 <details><summary>Tips for working with GPG keys</summary>
 
@@ -79,6 +79,12 @@ So you may skip them in command line invocation in case you have aws config.
    ```
 
 </details>
+
+* `MKREPO_DEB_ORIGIN` - the value of the ["Origin"](https://wiki.debian.org/DebianRepository/Format#Origin)
+  field of the "Release" file.
+* `MKREPO_DEB_LABEL` - the value of the ["Label"](https://wiki.debian.org/DebianRepository/Format#Label)
+  field of the "Release" file.
+* `MKREPO_DEB_DESCRIPTION` - the value of the "Description" field of the "Release" file.
 
 ## How it works
 

--- a/debrepo.py
+++ b/debrepo.py
@@ -415,13 +415,14 @@ def update_repo(storage, sign, tempdir):
     for dist in dists:
         release = Release()
 
-        release['Origin'] = 'Repo generator'
-        release['Label'] = 'Repo generator'
+        release['Origin'] = os.getenv('MKREPO_DEB_ORIGIN') or 'Repo generator'
+        release['Label'] = os.getenv('MKREPO_DEB_LABEL') or 'Repo generator'
         release['Codename'] = dist
         release['Date'] = creation_date
         release['Architectures'] = ' '.join(architectures[dist])
         release['Components'] = ' '.join(components[dist])
-        release['Description'] = 'Repo generator'
+        release['Description'] = os.getenv('MKREPO_DEB_DESCRIPTION')\
+            or 'Repo generator'
 
         checksum_lines = collections.defaultdict(list)
         checksum_names = {'md5': 'MD5Sum', 'sha1': 'SHA1', 'sha256': 'SHA256'}


### PR DESCRIPTION
Added the ability to specify the values of several fields ("Source", "Label" and "Description") for the "Release" file through environment variables.

Closes #22