### PR TITLE
Fix processing of the "revision" field

### DIFF
--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -123,7 +123,11 @@ def parse_repomd(data):
     filelists = None
     primary = None
 
-    revision = root.find('repo:revision', namespaces).text
+    # The revision is an optional XML element and may be absent.
+    revision = '0'
+    revision_element = root.find('repo:revision', namespaces)
+    if revision_element:
+        revision = revision_element.text
 
     for child in root:
         if 'type' not in child.attrib:


### PR DESCRIPTION
Before the patch, processing of the "repomd.xml" file will fail because there is no "revision" field.