### PR TITLE
Add force mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ So you may skip them in command line invocation in case you have aws config.
             [--s3-endpoint S3_ENDPOINT]
             [--s3-region S3_REGION]
             [--sign]
+            [--force]
             path [path ...]
 ```
 
@@ -49,6 +50,9 @@ So you may skip them in command line invocation in case you have aws config.
 * `--s3-endpoint` - /(optional)/ specify S3 server URI
 * `--s3-region` - /(optional)/ specify S3 region (default is us-east-1)
 * `--sign` - /(optional) sign package metadata
+* `--force` - /(optional) when adding packages to the index, the malformed one
+  will be skipped. By default, a malformed package will cause the utility to
+  stop working. The malformed_list.txt file will also be added to the repository
 * `path` - specify list of path to scan for repositories
 
 ## Environment variables reference

--- a/mkrepo.py
+++ b/mkrepo.py
@@ -51,10 +51,10 @@ def update_repo(path, args):
 
     if is_deb_repo(stor):
         print("Updating deb repository: %s" % path)
-        debrepo.update_repo(stor, args.sign, args.temp_dir)
+        debrepo.update_repo(stor, args.sign, args.temp_dir, args.force)
     elif is_rpm_repo(stor):
         print("Updating rpm repository: %s" % path)
-        rpmrepo.update_repo(stor, args.sign, args.temp_dir)
+        rpmrepo.update_repo(stor, args.sign, args.temp_dir, args.force)
     else:
         print("Unknown repository: %s" % path)
 
@@ -85,6 +85,17 @@ def main():
         action='store_true',
         default=False,
         help='sign package metadata')
+
+    parser.add_argument(
+        '--force',
+        action='store_true',
+        default=False,
+        help="""when adding packages to the index, the malformed one will be
+              skipped. By default, a malformed package will cause the utility
+              to stop working. The malformed_list.txt file will also be added
+              to the repository
+              """
+        )
 
     parser.add_argument(
         'path', nargs='+',

--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -760,7 +760,24 @@ def generate_repomd(filelists_str, filelists_gz, primary_str, primary_gz, revisi
     return res
 
 
-def update_repo(storage, sign, tempdir):
+def save_malformed_list(storage, malformed_list):
+    """Save the list of malformed packages to the storage.
+
+    Keyword arguments:
+    storage - storage with repositories (Storage object).
+    malformed_list - list of malformed packages (list of strings).
+    """
+    file = 'repodata/malformed_list.txt'
+    if malformed_list:
+        print('Save malformed list...')
+        storage.write_file(file, '\n'.join(malformed_list).encode('utf-8'))
+    elif storage.exists(file):
+        # The list existed before, but is not up-to-date now.
+        print('Delete malformed list...')
+        storage.delete_file(file)
+
+
+def update_repo(storage, sign, tempdir, force=False):
     filelists = {}
     primary = {}
     revision = "0"
@@ -797,6 +814,9 @@ def update_repo(storage, sign, tempdir):
         existing_files.add((file_path, mtime))
 
     files_to_add = existing_files - recorded_files
+    # List of packages that can't be added to the index
+    # (some problems encountered during processing).
+    malformed_list = []
 
     for file_to_add in files_to_add:
         file_path = file_to_add[0]
@@ -807,7 +827,18 @@ def update_repo(storage, sign, tempdir):
         storage.download_file(file_path, os.path.join(tmpdir, 'package.rpm'))
 
         rpminfo = rpmfile.RpmInfo()
-        header = rpminfo.parse_file(os.path.join(tmpdir, 'package.rpm'))
+        header = None
+
+        try:
+            header = rpminfo.parse_file(os.path.join(tmpdir, 'package.rpm'))
+        except Exception as err:
+            print("Can't parse '%s':\n%s" % (file_path, str(err)))
+            if force:
+                malformed_list.append(file_path)
+                continue
+            else:
+                raise err
+
         sha256 = file_checksum(os.path.join(tmpdir, 'package.rpm'), "sha256")
 
         statinfo = os.stat(os.path.join(tmpdir, 'package.rpm'))
@@ -822,6 +853,8 @@ def update_repo(storage, sign, tempdir):
 
         primary[nerv] = prim
         filelists[nerv] = flist
+
+    save_malformed_list(storage, malformed_list)
 
     revision = str(int(revision) + 1)
 


### PR DESCRIPTION
Now, when adding packages to the index, if an malformed package is present, the program will be terminated. In some cases, the desired program behavior is to correctly create an index with all correct packages and display a message about the presence of
malformed ones.
This behavior can now be set using the "--force" option.