### PR TITLE
Fix processing several fields from a Release file

### DIFF
--- a/debrepo.py
+++ b/debrepo.py
@@ -318,8 +318,8 @@ def update_repo(storage, sign, tempdir, force=False):
         release.parse_string(storage.read_file('dists/%s/Release' %
             dist).decode('utf-8'))
 
-        components = release['Components'].split(' ')
-        architectures = release['Architectures'].split(' ')
+        components = release['Components'].split()
+        architectures = release['Architectures'].split()
 
         for component in components:
             for arch in architectures:


### PR DESCRIPTION
Before the patch, the following expression was used when processing the "Architectures" and "Components" fields from the release file:
`architectures = release['Architectures'].split(' ')`
But in the case of `release['Architectures'] == ''` `architectures` will be `['']` and the following `for` will not work correctly (it will iterate for an empty `arch`). Now in the case of `release['Architectures'] == ''` `architectures` will be `[]` and `for` would not iterate over a such list.