### PR TITLE
deb: fix specifying of arch in PackageIndex

### DIFF
--- a/debrepo.py
+++ b/debrepo.py
@@ -494,7 +494,7 @@ def process_index_file(repo_info, path, dist, component, arch, index_type):
     index = None
 
     if index_type == 'packages':
-        index = PackageIndex()
+        index = PackageIndex(arch=arch)
     elif index_type == 'sources':
         index = SourceIndex()
     else:


### PR DESCRIPTION
Before this patch in PackageIndex the default arch is always use.
By a lucky coincidence, this did not break anything, but it may cause a bug in the future.