### PR TITLE
Fix architecture definition for srpm

### DIFF
--- a/rpmrepo.py
+++ b/rpmrepo.py
@@ -560,7 +560,7 @@ def header_to_other(header, sha256):
     """
     pkgid = sha256
     name = get_with_decode(header, 'NAME', None)
-    arch = get_with_decode(header, 'ARCH', None)
+    arch = get_arch_from_header(header)
     epoch = header.get('EPOCH', '0')
     rel = get_with_decode(header, 'RELEASE', None)
     ver = get_with_decode(header, 'VERSION', None)
@@ -651,10 +651,30 @@ def get_with_decode(dictionary, key, default='', encoding='utf-8'):
     return res
 
 
+def get_arch_from_header(header):
+    """Defines the architecture of the package according to
+    the data from the header.
+
+    Keyword arguments:
+    header - parsed rpm package header (dict)
+
+    Return the architecture the package is for (string)
+    """
+
+    # The architecture definition condition is based on
+    # https://github.com/rpm-software-management/yum/blob/4ed25525ee4781907bd204018c27f44948ed83fe/yum/packages.py#L2222
+    sourcepackage = header.get('SOURCEPACKAGE', None)
+    sourcerpm = get_with_decode(header, 'SOURCERPM', '')
+    if sourcepackage == 1 or not sourcerpm:
+        return 'src'
+    else:
+        return get_with_decode(header, 'ARCH', None)
+
+
 def header_to_filelists(header, sha256):
     pkgid = sha256
     name = get_with_decode(header, 'NAME', None)
-    arch = get_with_decode(header, 'ARCH', None)
+    arch = get_arch_from_header(header)
     epoch = header.get('EPOCH', '0')
     rel = get_with_decode(header, 'RELEASE', None)
     ver = get_with_decode(header, 'VERSION', None)
@@ -710,7 +730,7 @@ def header_to_primary(
         header_end,
         size):
     name = get_with_decode(header, 'NAME', None)
-    arch = get_with_decode(header, 'ARCH')
+    arch = get_arch_from_header(header)
     summary = get_with_decode(header, 'SUMMARY')
     description = get_with_decode(header, 'DESCRIPTION')
     packager = get_with_decode(header, 'PACKAGER', None)

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -149,6 +149,7 @@ class TestOtherGeneration(unittest.TestCase):
         sha_256_key = '9a791d16574dc3408f495eb383b6c2669b34fc4545b3c43c8c791fbbe10619d2'
         header = {
             'NAME': b'Test Package Header Other 1',
+            'SOURCERPM':b'tpho-0.0.1-1.fc34.src.rpm',
             'ARCH': b'aarch64',
             'EPOCH': 1,
             'RELEASE': b'10.el8_4',


### PR DESCRIPTION
Before the patch, the architecture of the package was written in
metadata for srpm, but this is not correct. For srpm, the
archetecture field must be filled with "src".

Tip:
To view the value of some tag in the rpm header use:
`rpm --query --package package.src.rpm --queryformat "%{TAG_NAME}\n"`

Related to tarantool/tarantool-qa#148