### PR TITLE
Add a long description to PIP package page

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,11 +1,19 @@
 #!/usr/bin/env python
+
 from distutils.core import setup
+from os import path
+
+this_directory = path.abspath(path.dirname(__file__))
+with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
+    long_description = f.read()
 
 setup(
     name='mkrepo',
     packages=[''],
     version='0.1.5',
     description='Maintain deb and rpm repos on s3',
+    long_description=long_description,
+    long_description_content_type="text/markdown",
     author='Konstantin Nazarov',
     author_email='mail@kn.am',
     url='https://github.com/tarantool/mkrepo',


### PR DESCRIPTION
For PIP project it is possible to show a detailed description of the
package. This is shown on the package detail page on the Python Package
Index [1]. Patch allows showing a long description loaded from
README.md, which is a common pattern [2].

1. https://pypi.org/project/mkrepo/
2. https://packaging.python.org/en/latest/tutorials/packaging-projects/#configuring-metadata